### PR TITLE
Update fts.c

### DIFF
--- a/drivers/input/touchscreen/fts_521/fts.c
+++ b/drivers/input/touchscreen/fts_521/fts.c
@@ -4953,7 +4953,7 @@ bool inline fts_touchmode_edgefilter(unsigned int touch_id, int x, int y)
 	return false;
 }
 
-int fts_read_touchmode_data()
+int fts_read_touchmode_data(void)
 {
 	int ret = 0;
 	u8 get_cmd[2] = {0xc1, 0x05};
@@ -5002,7 +5002,7 @@ int fts_read_touchmode_data()
 	return ret;
 }
 
-static void fts_init_touchmode_data()
+static void fts_init_touchmode_data(void)
 {
 	int i;
 
@@ -5124,7 +5124,7 @@ static void fts_edge_rejection(bool on, int value)
 	return;
 }
 
-static void fts_update_grip_mode()
+static void fts_update_grip_mode(void)
 {
 	int i, ret;
 	u8 grip_cmd[9] = {0xc0, 0x08, 0x00,};
@@ -5245,7 +5245,7 @@ static void fts_update_grip_mode()
 	return;
 }
 
-static void fts_update_touchmode_data()
+static void fts_update_touchmode_data(void)
 {
 	bool update = false;
 	int i, j, ret = 0;


### PR DESCRIPTION
../drivers/input/touchscreen/fts_521/fts.c:4956:28: error: this old-style function definition is not preceded by a prototype [-Werror,-Wstrict-prototypes]